### PR TITLE
Fixed DistReplacementPicker to prefer maximum version number

### DIFF
--- a/playless-lib/src/main/java/io/github/eterverda/playless/lib/DistReplacementPicker.java
+++ b/playless-lib/src/main/java/io/github/eterverda/playless/lib/DistReplacementPicker.java
@@ -38,6 +38,7 @@ public class DistReplacementPicker {
                 continue;
             }
             bestDist = candidate;
+            bestVersionCode = candidate.version.versionCode;
         }
         return bestDist;
     }

--- a/playless-lib/src/main/java/io/github/eterverda/playless/lib/DistReplacementPicker.java
+++ b/playless-lib/src/main/java/io/github/eterverda/playless/lib/DistReplacementPicker.java
@@ -34,7 +34,7 @@ public class DistReplacementPicker {
             if (candidate.version.versionCode <= bestVersionCode) {
                 continue;
             }
-            if (matcher.isCompatible(candidate.filter)) {
+            if (!matcher.isCompatible(candidate.filter)) {
                 continue;
             }
             bestDist = candidate;


### PR DESCRIPTION
Был баг, из-за которого из двух подходящих обновлений могло быть выбрано обновление НЕ с большим кодом версии, а с тем, которое было последним в списке. По правилам Google Play должно быть установлено обновление с большим номером.
